### PR TITLE
Calculate and subs in adjusted relative paths for assets

### DIFF
--- a/src/lt/plugins/css.cljs
+++ b/src/lt/plugins/css.cljs
@@ -80,8 +80,6 @@
                             code (if-not client-path
                                    (:code info)
                                    (preprocess (files/parent file-path) client-path (:code info)))]
-
-                        code
                         (clients/send client
                                       :editor.eval.css
                                       (assoc info :code code)


### PR DESCRIPTION
Currently only works for the LT-UI client. Silently passes code through unadjusted for other clients. The client for browser seems to lack a :type, so I'm going to have to dig through the client code to figure out how to identify it (or add a :type) and then figure out how to introspect to get the path to the file the code is being eval'd in.
